### PR TITLE
Resolved issue

### DIFF
--- a/aws/cc_lambda_event.py
+++ b/aws/cc_lambda_event.py
@@ -179,14 +179,14 @@ Make it happen.  Now!  *clap*clap*"""
     session = boto3.session.Session()
     ses = session.client('ses')
     if DEBUG_FLAG != True:
-        emailList = os.environ['Email_List']
+        emailList = os.environ['Email_List'].decode('string-escape')
     else:
         emailList = "(lp1\nS'jeremy@cloudcrier.com'\np2\na."
 
     ses.send_email(
         Source='CityCloud@CloudCrier.com',
         Destination={
-            'ToAddresses': cPickle.loads(emailList)
+            'ToAddresses': list(cPickle.loads(emailList))
         },
         Message={
             'Subject': {


### PR DESCRIPTION
Turns out was erroring out due to two issues. The email string, when abstracted to environment variable, was getting escaped (\n -> \n). Secondly, pickle was returning a 'set', while SES requires a 'list'